### PR TITLE
fix: numpy required version and fix get_collision_number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     python_requires='>=3.10',
     install_requires=[
-        'numpy',
+        'numpy==1.26.4',
         'pandas',
         'pyqtgraph',
         'PyQt5',

--- a/simworld/communicator/communicator.py
+++ b/simworld/communicator/communicator.py
@@ -465,8 +465,8 @@ class Communicator:
         human_collision_num = int(collision_data['HumanCollision'])
         object_collision_num = int(collision_data['ObjectCollision'])
         building_collision_num = int(collision_data['BuildingCollision'])
-        vehicle_collision_num = int(collision_data['VehicleCollision'])
-        return human_collision_num, object_collision_num, building_collision_num, vehicle_collision_num
+        # vehicle_collision_num = int(collision_data['VehicleCollision'])
+        return human_collision_num, object_collision_num, building_collision_num# vehicle_collision_num
 
     def get_position_and_direction(self, vehicle_ids=[], pedestrian_ids=[], traffic_signal_ids=[], humanoid_ids=[], scooter_ids=[]):
         """Get position and direction of vehicles, pedestrians, and traffic signals.


### PR DESCRIPTION
Issue:
1. Basic numpy installation with setup.py leads to installing numpy 2.x, which brings out error message that numpy needs to be 1.x.
2. unrealcv.get_collision_num seems to give a response excluding vehicle_collision_num, and it seems applied in local_planner, but not in communicator