### PR TITLE
docs: clarify packaged runtime plugin compatibility

### DIFF
--- a/docs/source/customization/make_your_own_pak.rst
+++ b/docs/source/customization/make_your_own_pak.rst
@@ -8,6 +8,46 @@ You can create your own .pak files to extend the environment or agent library of
    - We use Windows for this tutorial, but the steps are similar for Linux.
    - If you are on Windows, you can use cross-compiling to build pak files for Linux by referring to this document: `Unreal Engine Linux Cross-Compilation <https://dev.epicgames.com/documentation/en-us/unreal-engine/linux-development-requirements-for-unreal-engine?application_version=5.3#cross-compiletoolchain>`_.
 
+Runtime plugin compatibility
+----------------------------
+
+Before preparing assets, check that the SimWorld executable includes the
+runtime modules they require. A content ``.pak`` extends the assets available
+to the running executable; it does not enable or compile missing native
+runtime modules. Enabling a plugin in your asset-authoring project alone
+does not enable it in the official SimWorld executable.
+
+In the `maintainer response to issue #80 (February 15, 2026)
+<https://github.com/SimWorld-AI/SimWorld/issues/80#issuecomment-3905109317>`_,
+the following support was confirmed for the official build discussed there:
+
+.. list-table:: Reported runtime support
+   :header-rows: 1
+   :widths: 45 55
+
+   * - System
+     - Status
+   * - Control Rig / Full Body IK / IK Rig
+     - Enabled, confirmed by the maintainer
+   * - Chaos Cloth
+     - Enabled, confirmed by the maintainer
+   * - ML Deformer
+     - Not confirmed in that response
+   * - Physical Animation
+     - Not confirmed in that response; Chaos Cloth support alone does not
+       confirm support for this separate feature
+
+This is a dated confirmation, not an exhaustive plugin manifest for every
+release. For a system not confirmed above, ask the maintainers about the
+specific plugin and SimWorld package version before relying on it. Include
+the required plugin names when requesting support in a future build.
+If a required runtime module is absent, a SimWorld executable built with
+that module is needed; repackaging only the content will not add it.
+
+Once the runtime requirements are met, follow the matching Unreal Engine
+version and packaging steps below. Test the resulting assets in the target
+SimWorld package, including their animation and interaction behavior.
+
 1. Download the Unreal Editor
 -----------------------------
 
@@ -79,7 +119,7 @@ Open the created Data Asset and set the ``ChunkID``. Enable all options under ``
 
 .. important::
 
-   The ``ChunkID`` should be unique and not conflict with existing chunks in SimWorld. You can refer to the :doc:`additional_environments` to avoid conflicts.
+   The ``ChunkID`` should be unique and not conflict with existing chunks in SimWorld. You can refer to the :doc:`../getting_started/additional_environments` to avoid conflicts.
 
 
 6. Build the Pak File
@@ -97,4 +137,4 @@ Finally, package the project by navigating to ``Platforms > Windows > Package Pr
 7. Use the Pak File in SimWorld
 -------------------------------
 
-Copy the generated ``.pak`` file to the ``SimWorld/Content/Paks`` directory of your SimWorld installation. You can now load the new environment or assets in SimWorld by specifying the corresponding Map URI or asset path. Refer to the :doc:`additional_environments` for loading instructions.
+Copy the generated ``.pak`` file to the ``SimWorld/Content/Paks`` directory of your SimWorld installation. You can now load the new environment or assets in SimWorld by specifying the corresponding Map URI or asset path. Refer to the :doc:`../getting_started/additional_environments` for loading instructions.


### PR DESCRIPTION
Custom `.pak` users currently have no runtime-plugin compatibility guidance in the packaging tutorial. Add the support information confirmed by the maintainer in [issue #80](https://github.com/SimWorld-AI/SimWorld/issues/80#issuecomment-3905109317), dated February 15, 2026: Control Rig / Full Body IK / IK Rig and Chaos Cloth are enabled in the build discussed there. Explicitly leave ML Deformer and Physical Animation unconfirmed rather than inferring support.

Explain the distinction between content packaging and executable runtime modules, and fix the tutorial's two broken Additional Environments links.

Refs #80. This documents the existing confirmation; it does not enable plugins, assert a complete manifest for later releases, or close the remaining unconfirmed capabilities.

### Validation evidence

- Sphinx 7.1.2 HTML builds successfully on Python 3.10.
- Compared against unmodified `1f588ec`: **3 warnings before, 1 after**. Both repaired `additional_environments` references now resolve; the remaining warning is the existing unrelated `components/citygen.md:135` reference to `unrealcv+.md`.
- Parsed the generated HTML to verify the support matrix, dated primary-source link, and both repaired links and their target file.
- `git diff --check` passes.

Follow-up runtime verification: launched the complete official Base20260201 Windows package (ZIP SHA-256 `b737c33da55a068f142974d28dd83dfd1f32de86800ee469c312653c55810e5f`). Its UE 5.3.2 startup log records mounting **ControlRig, FullBodyIK, IKRig, and ChaosCloth**, consistent with the documented maintainer confirmation. [Committed engine log excerpt](https://github.com/chaiyuntian/SimWorld/blob/84f52f9e437e934063f7950a45a3339960e1567e/evidence/runtime-spawn-sensors/engine-log-excerpt.txt) and [package/reproduction details](https://github.com/chaiyuntian/SimWorld/tree/84f52f9e437e934063f7950a45a3339960e1567e/evidence/runtime-spawn-sensors).

This confirms plugin mounting in that Windows release. Custom content packaging, ML Deformer, and Physical Animation remain unverified; mounting `DeformerGraph` is not evidence of ML Deformer support.
